### PR TITLE
de-duplicate link to OpenDTU-OnBattery project

### DIFF
--- a/docs/3rd_party/related.md
+++ b/docs/3rd_party/related.md
@@ -2,9 +2,8 @@
 
 * [Ahoy](https://github.com/grindylow/ahoy){target=_blank}
 * [DTU Simulator](https://github.com/Ziyatoe/DTUsimMI1x00-Hoymiles){target=_blank}
-* [OpenDTU extended to talk to Victrons MPPT battery chargers (Ve.Direct)](https://github.com/helgeerbe/OpenDTU_VeDirect){target=_blank}
+* [OpenDTU-OnBattery](https://github.com/helgeerbe/OpenDTU-OnBattery){target=_blank} (support for additional peripherals and dynamic power limiting)
 * [Dynamic Limit Management](https://github.com/gf78/dynamic-limit-managment-opendtu-shelly/){target=_blank}
 * [ioBroker.opendtu](https://github.com/o0shojo0o/ioBroker.opendtu){target=_blank}
-* [OpenDTU-onBattery](https://github.com/helgeerbe/OpenDTU-OnBattery){target=_blank}
 * [OpenDTU React Native](https://github.com/OpenDTU-App/opendtu-react-native){target=_blank}
 * [OpenDTU - Web Installer](https://solar.metacontrol.eu/opendtu_webinstall/){target=_blank}


### PR DESCRIPTION
replace the legacy link, which redirects to the current project's location anyways (probably because the repo was renamed).