### PR TITLE
fix layout of links to videos

### DIFF
--- a/docs/firmware/compile_vscode.md
+++ b/docs/firmware/compile_vscode.md
@@ -37,5 +37,5 @@ requires a logout/login of the affected user).
 
 There are two videos showing these steps:
 
-    * [Git Clone and compilation](https://youtu.be/9cA_esv3zeA){target=_blank}
-    * [Full installation and compilation](https://youtu.be/xs6TqHn7QWM){target=_blank}
+* [Git Clone and compilation](https://youtu.be/9cA_esv3zeA){target=_blank}
+* [Full installation and compilation](https://youtu.be/xs6TqHn7QWM){target=_blank}


### PR DESCRIPTION
lines must not be indented, as the lines are then typeset as code.