### PR TITLE
doploy to gh-pages only when pushing to branch "master"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,4 +31,6 @@ jobs:
           restore-keys: |
             mkdocs-material-
 
-      - run: mkdocs gh-deploy --force
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/master'
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
avoid [failing actions in forks](https://github.com/schlimmchen/ODTUOBdocs/actions/runs/11281090497) and potentially keep you, Thomas, from accidentally deploying a branch that should not have been deployed :wink: