### PR TITLE
Updated details in the flash_esp for the use of esptool in Linux

### DIFF
--- a/docs/firmware/flash_esp.md
+++ b/docs/firmware/flash_esp.md
@@ -91,8 +91,12 @@ tab below that matches your flash tool.
     ```
 
     * Adjust the `--chip` parameter to the actual chip in use, e.g., `esp32-s3`.
-    * Change `COM1` to the correct port on your computer.
+    * Change `COM1` to the correct port on your computer.[^1]
     * In case you get an error at the end of the flash procedure, you can try again using a lower baudrate eg. 460800.
+
+[^1]: Linux only: A quick way to find ot the correct port name is to use the command `ls -l /dev/tty*` and pick the last name in the list, e.g. `/dev/ttyUSB0`.
+    If you encounter the error `Invalid value for '--port' / '-p': Path '/dev/ttyUSB0' is not readable.`, the command `sudo chmod a+rw /dev/ttyUSB0` temporarily grants the required permissions.
+
 
 === "ESP_Flasher :material-microsoft-windows:"
 

--- a/docs/firmware/flash_esp.md
+++ b/docs/firmware/flash_esp.md
@@ -84,9 +84,9 @@ tab below that matches your flash tool.
     esptool --port COM1 erase_flash
 
     esptool --baud 921600 --port COM1 --chip esp32 \
-        --before default_reset --after hard_reset \
-        write_flash --flash_mode dout \
-        --flash_freq 40m --flash_size detect \
+        --before default-reset --after hard-reset \
+        write-flash --flash-mode dout \
+        --flash-freq 40m --flash-size detect \
         0x0 opendtu-generic*.factory.bin
     ```
 


### PR DESCRIPTION
The version `esptool v5.0.1` considers the use of `_` deprecated and issues a warning. The command line has been adjusted according to the change.

In Linux, it is not trivial to figure out the correct port name. In addition the port may not have the required permissions to read and write date. A footnote with two short commands gives some additional guidance.