### PR TITLE
update discord link to point to expected channel

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,6 @@ This will help with offsetting the cost of the different hardware devices we sup
 
 [1]: https://www.hoymiles.com/
 [2]: https://www.github.com/tbnobody/OpenDTU/discussions
-[3]: https://discord.gg/WzhxEY62mB
+[3]: https://discord.gg/3QnqGdcq
 
 [^1]: Data Transfer Unit


### PR DESCRIPTION
the new link points directly to channel "support-opendtu" on the "hoymiles research" server.